### PR TITLE
Add logging via RabbitMQ to Spring Travel

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -273,6 +273,11 @@
             <version>${org.springframework-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.amqp</groupId>
+            <artifactId>spring-rabbit</artifactId>
+            <version>1.0.0.RELEASE</version>
+        </dependency>
     </dependencies>
     <repositories>
         <!-- For testing against latest Spring snapshots -->

--- a/server/src/main/java/org/springframework/samples/travel/web/Log4jConfigListener.java
+++ b/server/src/main/java/org/springframework/samples/travel/web/Log4jConfigListener.java
@@ -3,7 +3,6 @@ package org.springframework.samples.travel.web;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
-import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.cloudfoundry.runtime.env.CloudEnvironment;
 import org.cloudfoundry.runtime.env.RabbitServiceInfo;
@@ -17,50 +16,33 @@ public class Log4jConfigListener implements ServletContextListener {
 	public void contextInitialized(ServletContextEvent event) {
 		Log4jWebConfigurer.initLogging(event.getServletContext());
 
-		AmqpAppender amqpAppender;
 		CloudEnvironment cloudEnvironment = new CloudEnvironment();
 		if (cloudEnvironment.isCloudFoundry()) {
-			amqpAppender = createCloudFoundryAppender(cloudEnvironment);
+			initCloudFoundryAppender(cloudEnvironment);
 		}
-		else {
-			amqpAppender = createLocalAppender();
-		}
-		
-		Logger.getRootLogger().addAppender(amqpAppender);
 	}
  
 	public void contextDestroyed(ServletContextEvent event) {
 		Log4jWebConfigurer.shutdownLogging(event.getServletContext());
 	}
 	
-	AmqpAppender createCloudFoundryAppender(CloudEnvironment env) {
-		RabbitServiceInfo rabbitServiceInfo = env.getServiceInfo("rabbitmq-logs", RabbitServiceInfo.class);
-		AmqpAppender amqpAppender = createAmqpAppender();
-		amqpAppender.setHost(rabbitServiceInfo.getHost());
-		amqpAppender.setPort(rabbitServiceInfo.getPort());
-		amqpAppender.setVirtualHost(rabbitServiceInfo.getVirtualHost());
-		amqpAppender.setUsername(rabbitServiceInfo.getUserName());
-		amqpAppender.setPassword(rabbitServiceInfo.getPassword());
-		return amqpAppender;
+	void initCloudFoundryAppender(CloudEnvironment env) {
+		try {
+			RabbitServiceInfo rabbitServiceInfo = env.getServiceInfo("rabbitmq-logs", RabbitServiceInfo.class);
+			AmqpAppender amqpAppender = getAmqpAppender();
+			amqpAppender.close();                                 // Required for changes to take effect
+			amqpAppender.setHost(rabbitServiceInfo.getHost());
+			amqpAppender.setPort(rabbitServiceInfo.getPort());
+			amqpAppender.setVirtualHost(rabbitServiceInfo.getVirtualHost());
+			amqpAppender.setUsername(rabbitServiceInfo.getUserName());
+			amqpAppender.setPassword(rabbitServiceInfo.getPassword());
+		}
+		catch (Throwable t) {
+			t.printStackTrace();
+		}
 	}
 	
-	AmqpAppender createLocalAppender() {
-		AmqpAppender amqpAppender = createAmqpAppender();
-		amqpAppender.setHost("localhost");
-		amqpAppender.setVirtualHost("/");
-		amqpAppender.setUsername("guest");
-		amqpAppender.setPassword("guest");
-		return amqpAppender;
-	}
-	
-	AmqpAppender createAmqpAppender() {
-		AmqpAppender amqpAppender = new AmqpAppender();
-		amqpAppender.setName("rabbit");
-		amqpAppender.setExchangeName("amq.topic");
-		amqpAppender.setExchangeType("topic");
-		amqpAppender.setRoutingKeyPattern("logs.spring-travel");
-		amqpAppender.setApplicationId("spring-travel");
-		amqpAppender.setThreshold(Level.INFO);
-		return amqpAppender;
+	AmqpAppender getAmqpAppender() {
+		return (AmqpAppender) Logger.getRootLogger().getAppender("amqp");
 	}
 }

--- a/server/src/main/java/org/springframework/samples/travel/web/Log4jConfigListener.java
+++ b/server/src/main/java/org/springframework/samples/travel/web/Log4jConfigListener.java
@@ -1,0 +1,66 @@
+package org.springframework.samples.travel.web;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.cloudfoundry.runtime.env.CloudEnvironment;
+import org.cloudfoundry.runtime.env.RabbitServiceInfo;
+import org.springframework.amqp.rabbit.log4j.AmqpAppender;
+import org.springframework.web.util.Log4jWebConfigurer;
+
+/**
+ * Dynamic configuration of Log4j with an AMQP appender.
+ */
+public class Log4jConfigListener implements ServletContextListener {
+	public void contextInitialized(ServletContextEvent event) {
+		Log4jWebConfigurer.initLogging(event.getServletContext());
+
+		AmqpAppender amqpAppender;
+		CloudEnvironment cloudEnvironment = new CloudEnvironment();
+		if (cloudEnvironment.isCloudFoundry()) {
+			amqpAppender = createCloudFoundryAppender(cloudEnvironment);
+		}
+		else {
+			amqpAppender = createLocalAppender();
+		}
+		
+		Logger.getRootLogger().addAppender(amqpAppender);
+	}
+ 
+	public void contextDestroyed(ServletContextEvent event) {
+		Log4jWebConfigurer.shutdownLogging(event.getServletContext());
+	}
+	
+	AmqpAppender createCloudFoundryAppender(CloudEnvironment env) {
+		RabbitServiceInfo rabbitServiceInfo = env.getServiceInfo("rabbitmq-logs", RabbitServiceInfo.class);
+		AmqpAppender amqpAppender = createAmqpAppender();
+		amqpAppender.setHost(rabbitServiceInfo.getHost());
+		amqpAppender.setPort(rabbitServiceInfo.getPort());
+		amqpAppender.setVirtualHost(rabbitServiceInfo.getVirtualHost());
+		amqpAppender.setUsername(rabbitServiceInfo.getUserName());
+		amqpAppender.setPassword(rabbitServiceInfo.getPassword());
+		return amqpAppender;
+	}
+	
+	AmqpAppender createLocalAppender() {
+		AmqpAppender amqpAppender = createAmqpAppender();
+		amqpAppender.setHost("localhost");
+		amqpAppender.setVirtualHost("/");
+		amqpAppender.setUsername("guest");
+		amqpAppender.setPassword("guest");
+		return amqpAppender;
+	}
+	
+	AmqpAppender createAmqpAppender() {
+		AmqpAppender amqpAppender = new AmqpAppender();
+		amqpAppender.setName("rabbit");
+		amqpAppender.setExchangeName("amq.topic");
+		amqpAppender.setExchangeType("topic");
+		amqpAppender.setRoutingKeyPattern("logs.spring-travel");
+		amqpAppender.setApplicationId("spring-travel");
+		amqpAppender.setThreshold(Level.INFO);
+		return amqpAppender;
+	}
+}

--- a/server/src/main/resources/log4j.xml
+++ b/server/src/main/resources/log4j.xml
@@ -9,6 +9,13 @@
 			<param name="ConversionPattern" value="%-5p: %c - %m%n" />
 		</layout>
 	</appender>
+	
+	<appender name="amqp" class="org.springframework.amqp.rabbit.log4j.AmqpAppender">
+		<param name="ExchangeName" value="amq.topic" />
+		<param name="ExchangeType" value="topic" />
+		<param name="RoutingKeyPattern" value="logs.spring-travel" />
+		<param name="ApplicationId" value="spring-travel" />
+	</appender>
 
 	<!-- Application Loggers -->
 	<logger name="org.springframework.samples.travel">
@@ -63,8 +70,9 @@
 
 	<!-- Root Logger -->
 	<root>
-		<priority value="warn" />
+		<priority value="info" />
 		<appender-ref ref="console" />
+		<appender-ref ref="amqp"/>
 	</root>
 
 </log4j:configuration>

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -10,6 +10,9 @@
 <listener>
 		<listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
 	</listener>
+	<listener>
+		<listener-class>org.springframework.samples.travel.web.Log4jConfigListener</listener-class>
+	</listener>
 	<!-- Creates the Spring Container shared by all Servlets and Filters -->
 <!--	-->
 


### PR DESCRIPTION
I've added a servlet context listener that configures Log4j as usual then adds an AMQP appender that logs messages at INFO and above to a RabbitMQ service called "rabbitmq-logs". If the app is not running inside Cloud Foundry, it uses a local RabbitMQ with the usual 'guest' account.

I'd appreciate someone with a more solid Spring/Java background checking this. Too much is currently hard-coded, but I'm not sure what the best approach is for specifying the RabbitMQ connection settings.
