### PR TITLE
Limit DS pool size to allow app to start on PWS trial account

### DIFF
--- a/server/src/main/resources/META-INF/spring/travel/ds.xml
+++ b/server/src/main/resources/META-INF/spring/travel/ds.xml
@@ -36,7 +36,9 @@
 	</beans>
 
 	<beans profile="cloud">
-		<cloud:data-source id="ds" />
+		<cloud:data-source id="ds">
+			<cloud:pool pool-size="4" max-wait-time="200" />
+		</cloud:data-source>
 		<bean id="jpaVendorAdapter"
 			class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter" p:database="MYSQL">
 		</bean>


### PR DESCRIPTION
As written in the commit comment, I had to limit the cloud ds pool size to 4.
This is the max value when using the free ClearDB/MySQL Spark DB service that comes with a Pivotal Web Service free trial account.
The default value (8) was causing the app to crash on startup (max_user_connections exceeded)
